### PR TITLE
Fix controls alignment and HUD overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,6 +17,7 @@ body {
 }
     .container { position: relative; text-align: center; width: 100%; max-width: 600px; box-sizing: border-box; display: flex; flex-direction: column; align-items: center; }
     #gameCanvas { background: radial-gradient(circle, #000046, #000000); border: 2px solid #3b82f6; box-shadow: 0 0 20px rgba(59, 130, 246, 0.5); border-radius: 16px; width: 100%; height: auto; max-height: calc(100vh - 150px); aspect-ratio: 3/4; display: block; margin: 0 auto; cursor: crosshair; position: relative; }
+/* Controls row keeps bottom buttons centered */
 .controls-row {
   position: fixed;
   bottom: 1rem;
@@ -25,6 +26,7 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.75rem;
   width: calc(100% - 2rem);
   max-width: 600px;
@@ -36,7 +38,7 @@ body {
 #muteButton,
 #missionsButton,
 #menuButton {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   min-width: 80px;
   padding: clamp(0.5rem, 2vw, 0.8rem) clamp(0.8rem, 3vw, 1.2rem);
   font-size: clamp(0.7rem, 2vw, 1rem);
@@ -105,6 +107,10 @@ body {
       border: 1.5px solid #f59e0b;
       color: #fcd34d;
       text-shadow: 0 0 6px rgba(252, 211, 77, 0.8);
+      max-width: calc(100% - 140px);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     #activePowerUpDisplay { top: 45px; right: 15px; border: 1.5px solid #a78bfa; color: #d8b4fe; }
     #activePowerUpDisplay img { width: 1.2em; height: 1.2em; vertical-align: middle; margin-right: 5px;}
@@ -141,6 +147,7 @@ body {
   .controls-row {
     bottom: 8.5rem;
     gap: 1rem;
+    flex-wrap: wrap;
   }
 
   #startButton,


### PR DESCRIPTION
## Summary
- keep bottom controls centered and allow wrapping
- prevent stretching of individual control buttons
- limit combo display width to avoid overlap

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68433d69567c8328864d4c78d8053f33