### PR TITLE
Fix mobile button layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,6 +54,26 @@ body {
   justify-content: center;
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.4);
   font-family: 'Press Start 2P', 'Orbitron', cursive;
+  box-sizing: border-box;
+  white-space: nowrap;
+}
+
+/* Ensure text stays centered and buttons don't shift on touch */
+button {
+  -webkit-tap-highlight-color: transparent;
+}
+
+#startButton span,
+#pauseButton span,
+#menuButton span {
+  display: inline-block;
+  pointer-events: none;
+}
+
+#startButton:focus,
+#pauseButton:focus,
+#menuButton:focus {
+  outline: none;
 }
 
     #missionsButton { background: linear-gradient(135deg, #f59e0b 0%, #fcd34d 100%); }
@@ -71,7 +91,7 @@ body {
     #newGameButton { margin-top: 15px; padding: 12px 25px; font-size: 1.1rem; cursor: pointer; background: linear-gradient(135deg, #f87171 0%, #fcd34d 100%); color: #fff; border: none; border-radius: 25px; box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.3); transition: all 0.3s ease 0s; display: inline-flex; align-items: center; justify-content: center; width: auto; min-width: 160px; text-shadow: 2px 2px 4px rgba(0,0,0,0.5); font-family: 'Press Start 2P', cursive; }
     #newGameButton:hover { background: linear-gradient(135deg, #fca5a5 0%, #fde047 100%); box-shadow: 0px 15px 20px rgba(252, 211, 77, 0.4); transform: translateY(-3px); }
     #newGameButton:active { transform: translateY(1px); box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.2); }
-    button img { width: 1.1rem; height: 1.1rem; margin-right: 0.4rem; }
+    button img { width: 1.1rem; height: 1.1rem; margin-right: 0.4rem; pointer-events: none; }
     #missionsButton img { margin-right: 0.3rem; }
     .touch-controls-grid { display: none; }
     #mobileControlsContainer { display: none; position: fixed; bottom: 0; left: 0; width: 100%; height: 120px; padding: 10px 20px; box-sizing: border-box; display: flex; justify-content: space-between; align-items: center; z-index: 150; pointer-events: none; }


### PR DESCRIPTION
## Summary
- keep Start, Pause, and Menu button text inside the buttons
- disable touch highlight on buttons and ignore pointer events on icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68433fe14d9083288caab03564f85bd9