### PR TITLE
Fix mobile button shift when starting game

### DIFF
--- a/style.css
+++ b/style.css
@@ -180,6 +180,12 @@ button {
     padding: 0.8rem 1.2rem;
   }
 
+  /* Prevent buttons from shifting position when tapped on mobile */
+  #startButton:active,
+  #pauseButton:active {
+    transform: none;
+  }
+
   #message {
     top: 70px;
   }


### PR DESCRIPTION
## Summary
- prevent start/resume buttons from shifting on mobile

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684359174a408328bcf6c87841094723