### PR TITLE
Center messages and reduce font size

### DIFF
--- a/style.css
+++ b/style.css
@@ -103,7 +103,7 @@ button {
     #message, #comboDisplay, #activePowerUpDisplay { position: absolute; background-color: transparent; border: none; padding: 0; color: #f8fafc; font-size: 0.9rem; text-align: center; text-shadow: 1px 1px 2px rgba(0,0,0,0.6); z-index: 100; max-width: 80%; white-space: pre-wrap; word-wrap: break-word; opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0s 0.3s; }
     #gameOverMessage { position: absolute; background-color: rgba(0, 0, 0, 0.75); border-radius: 6px; padding: 20px; color: #f8fafc; font-size: 1.3rem; text-align: center; text-shadow: 1px 1px 2px rgba(0,0,0,0.6); z-index: 100; max-width: 80%; box-shadow: 0 2px 10px rgba(0,0,0,0.3); opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0s 0.3s; }
     #message.visible, #gameOverMessage.visible, #comboDisplay.visible, #activePowerUpDisplay.visible { opacity: 1; visibility: visible; transition: opacity 0.3s ease; }
-    #message { top: 45px; left: 50%; transform: translateX(-50%); }
+    #message { top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 0.8rem; }
     #gameOverMessage { top: 50%; left: 50%; transform: translate(-50%, -50%); border: 2px solid #f87171; padding: 20px; font-size: 1.3rem; }
     #gameOverMessage h2 { font-size: 1.8rem; color: #f87171; margin-bottom: 10px; }
     #gameOverMessage p { font-size: 1.1rem; margin-bottom: 15px; }
@@ -185,7 +185,7 @@ button {
   }
 
   #message {
-    top: 70px;
+    top: 50%;
   }
 
   #mobileControlsContainer {


### PR DESCRIPTION
## Summary
- center the message overlay and make its font smaller

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68436e7a3dc08328a71177da3fbe900b